### PR TITLE
Update Mattermost link to cp-chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,10 +112,10 @@ receiver is requested to reply promptly.
 #### Minimum required communication with Jeehoon
 
 - Everyday, please leave about five sentences to the
-  [하루한줄](https://cp-service.kaist.ac.kr/mm/cp/channels/one-line-a-day) mattermost channel about
+  [하루한줄](https://cp-chat.kaist.ac.kr/cp/channels/one-line-a-day) mattermost channel about
   what you'll do for the day.
 - Everyday, please leave about five sentences to the
-  [하루한줄](https://cp-service.kaist.ac.kr/mm/cp/channels/one-line-a-day) mattermost channel about
+  [하루한줄](https://cp-chat.kaist.ac.kr/cp/channels/one-line-a-day) mattermost channel about
   what you've done for the day.
 - Schedule at least one meeting for at least 15 minutes a week with Jeehoon. It can be about
   anything such as research, coursework, TA...

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ When you first come to the lab, please do the following instructions:
 - Your GitHub ID will be invited to `kaist-cp` organization.
 - You'll get {firstname}.{lastname}@cp.kaist.ac.kr Google Workspace account.
 - You'll get a Mattermost account in
-  [https://cp-service.kaist.ac.kr/mm](https://cp-service.kaist.ac.kr/mm). Click "Sign in with:
+  [https://cp-chat.kaist.ac.kr](https://cp-chat.kaist.ac.kr). Click "Sign in with:
   GitLab", and input your Google Workspace username and password.
 - Make sure you finish read this document, and send an email that says you did so to
   `jeehoon.kang@kaist.ac.kr`.
@@ -168,10 +168,10 @@ When you first come to the lab, please do the following instructions:
 
 #### Mattermost
 
-- Instant messaging service at https://cp-service.kaist.ac.kr/mm.
+- Instant messaging service at https://cp-chat.kaist.ac.kr.
 - Try to reply promptly in work hours. (No need to reply in other times.)
 - At the beginning of each work day, briefly state what you'll do that day at [this
-  channel](https://cp-service.kaist.ac.kr/mm/cp/channels/one-line-a-day).
+  channel](https://cp-chat.kaist.ac.kr/cp/channels/one-line-a-day).
 
 
 #### Face-to-face meeting


### PR DESCRIPTION
Mattermost channel이 `cp-service` 에서 `cp-chat`으로 바뀐 것을 반영해서 Mattermost hyperlink들을 업데이트했습니다.